### PR TITLE
Fix mkdocs deploy gh action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ jobs:
   conda-mkdocs:
     name: MkDocs
     runs-on: "ubuntu-latest"
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - uses: actions/checkout@v2
       - uses: goanpeca/setup-miniconda@v1


### PR DESCRIPTION
Add ACTIONS_ALLOW_UNSECURE_COMMANDS env variable, set to true. This is a stop gap measure to get the mkdocs deploy github action working again, for now.