### PR TITLE
Use upstream setup-miniconda action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - uses: actions/checkout@v2
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2.1.1
         with:
           activate-environment: foo
           python-version: 3.7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,6 @@ jobs:
   conda-mkdocs:
     name: MkDocs
     runs-on: "ubuntu-latest"
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2.1.1


### PR DESCRIPTION
The existing setup-miniconda action was from a fork, which has not been updated to set environment variables in a safe way. It appears that the upstream Github Action has been updated to support safe environment variable setting.